### PR TITLE
Adding method to untrack tracked properties

### DIFF
--- a/spec/basic-properties.spec.js
+++ b/spec/basic-properties.spec.js
@@ -91,5 +91,32 @@
 
         });
 
+        describe("ko.untrack()", function() {
+
+            it("releases the internal reference to the observable", function() {
+                var obj = { a: 1 };
+                ko.track(obj);
+
+                ko.untrack(obj);
+                expect(ko.getObservable(obj, "a")).toBeNull();
+            });
+
+            it("releases the internal reference to specified properties", function() {
+                var obj = { a: 1 };
+                ko.track(obj);
+
+                ko.untrack(obj, ["a"]);
+                expect(ko.getObservable(obj, "a")).toBeNull();
+            });
+
+            it("leaves properties tracked that aren't specified", function() {
+                var obj = { a: 1, b: 2 };
+                ko.track(obj);
+
+                ko.untrack(obj, ["a"]);
+                expect(ko.getObservable(obj, "b")).not.toBeNull();
+            });
+
+        });
     });
 })();

--- a/src/knockout-es5.js
+++ b/src/knockout-es5.js
@@ -93,6 +93,26 @@
         return result;
     }
 
+    // Removes the internal references to observables mapped to the specified properties
+    // or the entire object reference if no properties are passed in. This allows the
+    // observables to be replaced and tracked again.
+    function untrack(obj, propertyNames) {
+        if (!objectToObservableMap) {
+            return;
+        }
+
+        if (arguments.length === 1) {
+            objectToObservableMap.delete(obj);
+        } else {
+            var allObservablesForObject = getAllObservablesForObject(obj, false); 
+            if (allObservablesForObject) {
+                propertyNames.forEach(function(propertyName) {
+                    delete allObservablesForObject[propertyName];
+                });
+            }   
+        }
+    }
+
     // Computed properties
     // -------------------
     //
@@ -291,6 +311,7 @@
     // Extends a Knockout instance with Knockout-ES5 functionality
     function attachToKo(ko) {
         ko.track = track;
+        ko.untrack = untrack;
         ko.getObservable = getObservable;
         ko.valueHasMutated = valueHasMutated;
         ko.defineProperty = defineComputedProperty;


### PR DESCRIPTION
This removes registered properties from the internal weakmap so that they can be registered again with new  observables.

Fixed #18
