### PR TITLE
Removed "global" so that r.js optimizer picks it up

### DIFF
--- a/src/knockout-es5.js
+++ b/src/knockout-es5.js
@@ -332,8 +332,8 @@
             attachToKo(ko);
             weakMapFactory = function() { return new WM(); };
             module.exports = ko;
-        } else if (typeof global.define === 'function' && global.define.amd) {
-            global.define(['knockout'], function(koModule) {
+        } else if (typeof define === 'function' && define.amd) {
+            define(['knockout'], function(koModule) {
                 ko = koModule;
                 attachToKo(koModule);
                 weakMapFactory = function() { return new global.WeakMap(); };


### PR DESCRIPTION
r.js optimizer doesn't see the `global.define()` call so I replaced it by `define()`.

This should not have any unwanted consequences as this is the syntax that KO itself already uses.

Fixes #28.
