### PR TITLE
Adapt CommonJS Modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
 
     concat: {
       dist: {
-        src: ['src/knockout-es5.js', 'lib/weakmap.js'],
+        src: ['lib/weakmap.js', 'src/knockout-es5.js'],
         dest: 'dist/knockout-es5.js'
       }
     },

--- a/src/knockout-es5.js
+++ b/src/knockout-es5.js
@@ -330,7 +330,13 @@
     if (typeof exports === 'object' && typeof module === 'object') {
       // Node.js case - load KO and WeakMap modules synchronously
       ko = require('knockout');
-      var WM = require('weakmap');
+      var WM;
+      if (typeof module.exports === 'function') {
+        // Exported function from concatenated lib/weakmap.js
+        WM = module.exports;
+      } else {
+        WM = require('weakmap');
+      }
       attachToKo(ko);
       weakMapFactory = function() { return new WM(); };
       module.exports = ko;


### PR DESCRIPTION
Adapt CommonJS Modules used in Node.js, webpack, browserify, etc...
This will fix #31 .
I tested using with webpack.