### PR TITLE
Fix Access Denied Errors in IE 11

### DIFF
--- a/lib/weakmap.js
+++ b/lib/weakmap.js
@@ -30,6 +30,7 @@
 
 void function(global, undefined_, undefined){
   var getProps = Object.getOwnPropertyNames,
+      cachedWindowNames = typeof window === 'object' ? Object.getOwnPropertyNames(window) : [],
       defProp  = Object.defineProperty,
       toSource = Function.prototype.toString,
       create   = Object.create,
@@ -87,7 +88,16 @@ void function(global, undefined_, undefined){
 
     // common per-object storage area made visible by patching getOwnPropertyNames'
     define(Object, namedFunction('getOwnPropertyNames', function getOwnPropertyNames(obj){
-      var props = getProps(obj);
+      var coercedObj = Object(obj), props;
+      if (coercedObj.toString() === '[object Window]') {
+          try {
+              props = getProps(obj);
+          } catch (e) {
+              props = cachedWindowNames;
+          }
+      } else {
+          props = getProps(obj);
+      }
       if (hasOwn.call(obj, globalID))
         props.splice(props.indexOf(globalID), 1);
       return props;


### PR DESCRIPTION
Fix access denied errors in IE 11 when a cross origin frame tries to use
getOwnPropertyNames. Apparently IE has a bug where it uses the function
defined in the original window.

This is a similar fix as is in an ES6-Shim.

* paulmillr/es6-shim#333
* paulmillr/es6-shim@cee098d1cb451540e1e8f5341180964bbb66c66d

It seemed to address the issue for me. Am using knockout-es5 on Microsoft Office 365 where they create many cross origin iframes.