### PR TITLE
Throw useful error when calling track on invalid properties

### DIFF
--- a/dist/knockout-es5.js
+++ b/dist/knockout-es5.js
@@ -150,6 +150,10 @@
         return;
       }
 
+      if (!obj.hasOwnProperty(prop)) {
+        throw new Error('Property \'' + prop + '\' does not exist on the object to be tracked');
+      }
+
       // Skip properties where descriptor can't be redefined
       if (Object.getOwnPropertyDescriptor(obj, prop).configurable === false){
         return;

--- a/dist/knockout-es5.min.js
+++ b/dist/knockout-es5.min.js
@@ -50,9 +50,9 @@ return d[c]=function(){return g},(f||e&&"push"in g)&&m(w,g),{configurable:!0,enu
 // no need to be lazy if we already have an observable
 return f(a,b,c);var e;return c[b]=function(){return d(a)},{configurable:!0,enumerable:!0,get:function(){return d(a)()},set:function(a){d(a,!0)}}}function h(a,b,c){if(b.length){var d=j(a,!0),i={};b.forEach(function(b){
 // Skip properties that are already tracked
-if(!(b in d)&&Object.getOwnPropertyDescriptor(a,b).configurable!==!1)
+if(!(b in d)){if(!a.hasOwnProperty(b))throw new Error("Property '"+b+"' does not exist on the object to be tracked");
 // Skip properties where descriptor can't be redefined
-{var j=a[b];i[b]=(c.lazy?g:f)(j,b,d),c.deep&&e(j)&&h(j,Object.keys(j),c)}}),Object.defineProperties(a,i)}}function i(a){return!!a&&"object"==typeof a&&a.constructor===Object}
+if(Object.getOwnPropertyDescriptor(a,b).configurable!==!1){var j=a[b];i[b]=(c.lazy?g:f)(j,b,d),c.deep&&e(j)&&h(j,Object.keys(j),c)}}}),Object.defineProperties(a,i)}}function i(a){return!!a&&"object"==typeof a&&a.constructor===Object}
 // Gets or creates the hidden internal key-value collection of observables corresponding to
 // properties on the model object.
 function j(a,b){x||(x=z());var c=x.get(a);return!c&&b&&(c={},x.set(a,c)),c}

--- a/src/knockout-es5.js
+++ b/src/knockout-es5.js
@@ -150,6 +150,10 @@
         return;
       }
 
+      if (!obj.hasOwnProperty(prop)) {
+        throw new Error('Property \'' + prop + '\' does not exist on the object to be tracked');
+      }
+
       // Skip properties where descriptor can't be redefined
       if (Object.getOwnPropertyDescriptor(obj, prop).configurable === false){
         return;

--- a/test/basic-properties.test.js
+++ b/test/basic-properties.test.js
@@ -106,6 +106,12 @@ describe('Basic properties', function () {
       assert.strictEqual( result, true, result.message );
     });
 
+    it('throws if a property name does not exist on the object', function () {
+      assert.throw(function() {
+        ko.track({a: 1, b: 2}, ['a', 'z']);
+      }, 'Property \'z\' does not exist on the object to be tracked');
+    });
+
     it('retains existing observable properties, wrapping them in a getter/setter', function() {
       var observable = ko.observable(123),
         obj = ko.track({ prop: observable });


### PR DESCRIPTION
* previously when attempting to track invalid properties, the
  error thrown was
    "Cannot read property 'configurable' of undefined"
  which wasn't very useful for debugging
* also re-build dist