### PR TITLE
Fix for IE11 debugger

### DIFF
--- a/dist/knockout-es5.js
+++ b/dist/knockout-es5.js
@@ -559,7 +559,14 @@ void function(global, undefined_, undefined){
     define(Object, namedFunction('getOwnPropertyNames', function getOwnPropertyNames(obj){
       // gh-43
       var coercedObj = Object(obj), props;
-      if ('toString' in coercedObj && coercedObj.toString() === '[object Window]') {
+      // Fixes for debuggers:
+      // 1) Some objects lack .toString(), calling it on them make Chrome
+      // debugger fail when inspecting variables.
+      // 2) Window.prototype methods and properties are private in IE11 and
+      // throw 'Invalid calling object'.
+      if (coercedObj !== Window.prototype && 'toString' in coercedObj
+        && coercedObj.toString() === '[object Window]')
+      {
           try {
               props = getProps(obj);
           } catch (e) {

--- a/dist/knockout-es5.min.js
+++ b/dist/knockout-es5.min.js
@@ -180,7 +180,13 @@ return b._name=a,b}function g(a){function b(b,e){return e||2===arguments.length?
 // common per-object storage area made visible by patching getOwnPropertyNames'
 return d(Object,f("getOwnPropertyNames",function(a){
 // gh-43
-var b,c=Object(a);if("toString"in c&&"[object Window]"===c.toString())try{b=h(a)}catch(d){b=i}else b=h(a);return m.call(a,k)&&b.splice(b.indexOf(k),1),b})),d(a.prototype,f("get",function(a){return this.unlock(a).value})),d(a.prototype,f("set",function(a,b){this.unlock(a).value=b})),a}(),p=function(g){function h(b){return this===a||null==this||this===h.prototype?new h(b):(p(this,new o),void r(this,b))}function i(a){n(a);var d=q(this).get(a);return d===b?c:d}function j(a,d){n(a),
+var b,c=Object(a);
+// Fixes for debuggers:
+// 1) Some objects lack .toString(), calling it on them make Chrome
+// debugger fail when inspecting variables.
+// 2) Window.prototype methods and properties are private in IE11 and
+// throw 'Invalid calling object'.
+if(c!==Window.prototype&&"toString"in c&&"[object Window]"===c.toString())try{b=h(a)}catch(d){b=i}else b=h(a);return m.call(a,k)&&b.splice(b.indexOf(k),1),b})),d(a.prototype,f("get",function(a){return this.unlock(a).value})),d(a.prototype,f("set",function(a,b){this.unlock(a).value=b})),a}(),p=function(g){function h(b){return this===a||null==this||this===h.prototype?new h(b):(p(this,new o),void r(this,b))}function i(a){n(a);var d=q(this).get(a);return d===b?c:d}function j(a,d){n(a),
 // store a token for explicit undefined so that "has" works correctly
 q(this).set(a,d===c?b:d)}function k(a){return n(a),q(this).get(a)!==c}function l(a){n(a);var b=q(this),d=b.get(a)!==c;return b.set(a,c),d}function m(){return q(this),"[object WeakMap]"}var n=function(a){if(null==a||"object"!=typeof a&&"function"!=typeof a)throw new TypeError("Invalid WeakMap key")},p=function(a,b){var c=g.unlock(a);if(c.value)throw new TypeError("Object is already a WeakMap");c.value=b},q=function(a){var b=g.unlock(a).value;if(!b)throw new TypeError("WeakMap is not generic");return b},r=function(a,b){null!==b&&"object"==typeof b&&"function"==typeof b.forEach&&b.forEach(function(c,d){c instanceof Array&&2===c.length&&j.call(a,b[d][0],b[d][1])})};
 // Undo the function-name stripping that UglifyJS does

--- a/lib/weakmap.js
+++ b/lib/weakmap.js
@@ -90,7 +90,14 @@ void function(global, undefined_, undefined){
     define(Object, namedFunction('getOwnPropertyNames', function getOwnPropertyNames(obj){
       // gh-43
       var coercedObj = Object(obj), props;
-      if ('toString' in coercedObj && coercedObj.toString() === '[object Window]') {
+      // Fixes for debuggers:
+      // 1) Some objects lack .toString(), calling it on them make Chrome
+      // debugger fail when inspecting variables.
+      // 2) Window.prototype methods and properties are private in IE11 and
+      // throw 'Invalid calling object'.
+      if (coercedObj !== Window.prototype && 'toString' in coercedObj
+        && coercedObj.toString() === '[object Window]')
+      {
           try {
               props = getProps(obj);
           } catch (e) {


### PR DESCRIPTION
IE11 debugger sometimes throws when working with this library as it ends up calling `Object.getOwnPropertyNames(Window.prototype)`.

`WindowPrototype` methods and properties are private in Internet Explorer and they all throw when called or read, including `.toString()`.

This patch adds a check to avoid that and adds a comment documenting both this issue and my previous debugger fix for Chrome.