### PR TITLE
Added "subscribe" method to the plain array

### DIFF
--- a/test/arrays.test.js
+++ b/test/arrays.test.js
@@ -123,6 +123,22 @@ describe('Array handling', function () {
     assert.equal(lastNotifiedValue(), '');
   });
 
+  it('supports the subscribe method for more detailed notification - e.g. change tracking', function () {
+    var plainArray = ['a', 'b', 'c'],
+      obj = ko.track({ myArray: ko.observableArray(plainArray) }),
+      lastNotifiedValue;
+
+    // Subscribe to the 'arrayChange' notification.
+    plainArray.subscribe(function(changeSet) {
+        lastNotifiedValue = JSON.stringify(changeSet);
+    }, this, 'arrayChange');
+
+    // Adding an item. It should should up in the changeSet argument with a status of 'added'
+    plainArray.push('d');
+    assert.equal(lastNotifiedValue, '[{"status":"added","value":"d","index":3}]');
+  });
+
+
   it('only triggers one notification at the end of a Knockout mutator function', function() {
     var plainArray = [1, 2, 3, 4, 5],
       obj = ko.track({ myArray: plainArray }),


### PR DESCRIPTION
Added "subscribe" method to the plain array, to allow for deeper event subscription without having to get the observable.

This avoids having to call `ko.getObservable(model, "things")` all over the data-bind attributes.  You can just bind the tracked array same as you would an observableArray, and a binding that needs to subscribe can just call ".subscribe" on whatever kind of array it receives.  See new test in **arrays.tests.js** for example.